### PR TITLE
Parallelize eval analogy

### DIFF
--- a/src/analogy.py
+++ b/src/analogy.py
@@ -60,7 +60,7 @@ CODER_TYPE_TO_NAME = {"gpt2": "gpt2", "bert": "bert-base-cased"}
 
 # Set this when running experiments
 # TODO: make a parameter?
-OUTPUT_DIR = os.path.abspath("../../data/snli-b1/checkpoint-31250/")
+OUTPUT_DIR = os.path.abspath("../pretrained_models/optimus_snli10/checkpoint-31250/")
 
 
 def get_encoder(encoder_type="bert", output_encoder_dir="/tmp"):

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -3,7 +3,6 @@ import csv
 import funcy as f
 import pandas as pd
 import dask.dataframe as dd
-from dask.multiprocessing import get
 
 import analogy as a
 import score as s

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -65,7 +65,7 @@ def run_experiment(input_frame, n_samples=1, temperature=1):
     for col in new_columns:
         output_frame[col] = input_frame.map_partitions(
             lambda df: df.apply(evaluator, axis=1)
-        ).compute(scheduler="processes")
+        ).compute()
     return output_frame
 
 

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -136,7 +136,7 @@ def run(input_filename, output_filename, n_samples=1):
     On Ubuntu, you can get the number of cores with `grep -m 1 'cpu cores' /proc/cpuinfo.`
     """
     new_col_frame = run_experiment(
-        dd.from_pandas(input_frame[["a", "b", "c"]], npartitions=6),
+        dd.from_pandas(input_frame[["a", "b", "c"]], npartitions=8),
         n_samples=n_samples,
     )
     output_frame = pd.concat([input_frame, new_col_frame], axis=1)

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -131,9 +131,11 @@ def run(input_filename, output_filename, n_samples=1):
     input_frame = pd.read_csv(input_filename)
     # inputs, outputs = read_csv(input_filename)
     """
-    npartitions should be the number of cpus you have (the higher this is, the faster your computation will be)
+    npartitions should be the number of logical cores you have (the higher this is, the faster your computation will be)
 
     On Ubuntu, you can get the number of cores with `grep -m 1 'cpu cores' /proc/cpuinfo.`
+
+    On mac, you can do this with `sysctl -n hw.ncpu`
     """
     new_col_frame = run_experiment(
         dd.from_pandas(input_frame[["a", "b", "c"]], npartitions=8),


### PR DESCRIPTION
Improve speed of OPTIMUS analogy evaluation speed by using Dask to partition the dataframe and run the analogy evaluation in parallel.

Before, OPTIMUS took >4 hours to run a dataset of 10,000, now it should take under 2 hours if it is run with nothing else having significant CPU usage.

Timings (on my laptop with 3.1 GHz Quad-Core Intel Core i7) with 8 partitions:
300 rows: ~238 seconds or ~4 minutes
5000 rows: ~3183 seconds or ~53 minutes

resolves #2 